### PR TITLE
Introducing global settings variable to make quotes around number upon marshal optional

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,7 @@
 *.test
 *.out
 coverage.txt
+
+# IntelliJ
+.idea/
+*.iml

--- a/decimal.go
+++ b/decimal.go
@@ -26,21 +26,22 @@ const (
 )
 
 var (
-	NegOne              = MustNew(-1, 0)                         // NegOne represents the decimal value of -1.
-	Zero                = MustNew(0, 0)                          // Zero represents the decimal value of 0. For comparison purposes, use the IsZero method.
-	One                 = MustNew(1, 0)                          // One represents the decimal value of 1.
-	Two                 = MustNew(2, 0)                          // Two represents the decimal value of 2.
-	Ten                 = MustNew(10, 0)                         // Ten represents the decimal value of 10.
-	Hundred             = MustNew(100, 0)                        // Hundred represents the decimal value of 100.
-	Thousand            = MustNew(1_000, 0)                      // Thousand represents the decimal value of 1,000.
-	E                   = MustNew(2_718_281_828_459_045_235, 18) // E represents Euler’s number rounded to 18 digits.
-	Pi                  = MustNew(3_141_592_653_589_793_238, 18) // Pi represents the value of π rounded to 18 digits.
-	errDecimalOverflow  = errors.New("decimal overflow")
-	errInvalidDecimal   = errors.New("invalid decimal")
-	errScaleRange       = errors.New("scale out of range")
-	errInvalidOperation = errors.New("invalid operation")
-	errInexactDivision  = errors.New("inexact division")
-	errDivisionByZero   = errors.New("division by zero")
+	MarshalJSONWithoutQuotes = false                                  // MarshalJSONWithoutQuotes set to true if you want decimals to be JSON marshaled to number instead of string
+	NegOne                   = MustNew(-1, 0)                         // NegOne represents the decimal value of -1.
+	Zero                     = MustNew(0, 0)                          // Zero represents the decimal value of 0. For comparison purposes, use the IsZero method.
+	One                      = MustNew(1, 0)                          // One represents the decimal value of 1.
+	Two                      = MustNew(2, 0)                          // Two represents the decimal value of 2.
+	Ten                      = MustNew(10, 0)                         // Ten represents the decimal value of 10.
+	Hundred                  = MustNew(100, 0)                        // Hundred represents the decimal value of 100.
+	Thousand                 = MustNew(1_000, 0)                      // Thousand represents the decimal value of 1,000.
+	E                        = MustNew(2_718_281_828_459_045_235, 18) // E represents Euler’s number rounded to 18 digits.
+	Pi                       = MustNew(3_141_592_653_589_793_238, 18) // Pi represents the value of π rounded to 18 digits.
+	errDecimalOverflow       = errors.New("decimal overflow")
+	errInvalidDecimal        = errors.New("invalid decimal")
+	errScaleRange            = errors.New("scale out of range")
+	errInvalidOperation      = errors.New("invalid operation")
+	errInexactDivision       = errors.New("inexact division")
+	errDivisionByZero        = errors.New("division by zero")
 )
 
 // newUnsafe creates a new decimal without checking the scale and coefficient.
@@ -626,9 +627,13 @@ func (d *Decimal) UnmarshalJSON(data []byte) error {
 // [json.Marshaler]: https://pkg.go.dev/encoding/json#Marshaler
 func (d Decimal) MarshalJSON() ([]byte, error) {
 	text := make([]byte, 0, 26)
-	text = append(text, '"')
-	text = d.append(text)
-	text = append(text, '"')
+	if MarshalJSONWithoutQuotes {
+		text = d.append(text)
+	} else {
+		text = append(text, '"')
+		text = d.append(text)
+		text = append(text, '"')
+	}
 	return text, nil
 }
 

--- a/decimal_test.go
+++ b/decimal_test.go
@@ -541,6 +541,43 @@ func TestDecimalUnmarshalBinary(t *testing.T) {
 	})
 }
 
+func TestDecimalMarshalJSON(t *testing.T) {
+	tests := []struct {
+		d    Decimal
+		want string
+	}{
+		{MustNew(1000, 0), "1000"},
+		{MustNew(200002, 2), "2000.02"},
+		{MustNew(3000300, 3), "3000.300"},
+	}
+	t.Run("success", func(t *testing.T) {
+		for _, tt := range tests {
+			got, err := tt.d.MarshalJSON()
+			if err != nil {
+				t.Errorf("MarshalJSON(%s) failed: %v", tt.d.String(), err)
+				continue
+			}
+			if string(got) != `"`+tt.want+`"` {
+				t.Errorf("MarshalJSON(%s): got %s, want %s", tt.d.String(), string(got), tt.want)
+			}
+		}
+	})
+	MarshalJSONWithoutQuotes = true
+	t.Run("success", func(t *testing.T) {
+		for _, tt := range tests {
+			got, err := tt.d.MarshalJSON()
+			if err != nil {
+				t.Errorf("MarshalJSON(%s) failed: %v", tt.d.String(), err)
+				continue
+			}
+			if string(got) != tt.want {
+				t.Errorf("MarshalJSON(%s): got %s, want %s", tt.d.String(), string(got), tt.want)
+			}
+		}
+	})
+	MarshalJSONWithoutQuotes = false
+}
+
 func TestDecimalUnmarshalJSON(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		tests := []struct {


### PR DESCRIPTION
Fixes #59

Introducing variable `MarshalJSONWithoutQuotes` to indicate if the lib should wrap decimals in quotes or not upon marshalling. This is done the same way it has been implemented in [shopspring/decimal](https://github.com/shopspring/decimal)

I also added .idea to .gitignore. I noticed it wasn't ignored as I use GoLand. 